### PR TITLE
support nested transactions

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -115,3 +115,69 @@ func TestExample3(t *testing.T) {
 		t.Errorf("val should be nil, got %v", val)
 	}
 }
+
+func TestExample4(t *testing.T) {
+
+	db := database{}
+	db.store = make(map[string]string)
+	db.setBuf = make(map[string]string)
+
+	var val *string
+	var n uint
+
+	db.set("a", "foo")
+	db.set("b", "baz")
+
+	db.begin()
+
+	val = db.get("a")
+	if val == nil || *val != "foo" {
+		t.Errorf("val should be foo, got %v", val)
+	}
+
+	db.set("a", "bar")
+	n = db.count("bar")
+	if n != 1 {
+		t.Errorf("count should be 1, got %v", n)
+	}
+
+	db.begin()
+	n = db.count("bar")
+	if n != 1 {
+		t.Errorf("count should be 1, got %v", n)
+	}
+
+	db.delete("a")
+	val = db.get("a")
+	if val != nil {
+		t.Errorf("val should be nil, got %v", *val)
+	}
+
+	n = db.count("bar")
+	if n != 0 {
+		t.Errorf("count should be 0, got %v", n)
+	}
+
+	db.rollback()
+	val = db.get("a")
+	if val == nil || *val != "bar" {
+		t.Errorf("val should be bar, got %v", *val)
+	}
+
+	n = db.count("bar")
+	if n != 1 {
+		t.Errorf("count should be 1, got %v", n)
+	}
+
+	db.commit()
+
+	val = db.get("a")
+	if val == nil || *val != "bar" {
+		t.Errorf("val should be bar, got %v", *val)
+	}
+
+	val = db.get("b")
+	if val == nil || *val != "baz" {
+		t.Errorf("val should be baz, got %v", *val)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ func TestExample1(t *testing.T) {
 
 	db := database{
 		store: make(map[string]string),
+		txs:   new([]transaction),
 	}
 
 	var val *string
@@ -49,6 +50,7 @@ func TestExample2(t *testing.T) {
 
 	db := database{
 		store: make(map[string]string),
+		txs:   new([]transaction),
 	}
 
 	var val *string
@@ -82,6 +84,7 @@ func TestExample3(t *testing.T) {
 
 	db := database{
 		store: make(map[string]string),
+		txs:   new([]transaction),
 	}
 
 	var val *string
@@ -120,6 +123,7 @@ func TestExample4(t *testing.T) {
 
 	db := database{
 		store: make(map[string]string),
+		txs:   new([]transaction),
 	}
 
 	var val *string
@@ -157,10 +161,11 @@ func TestExample4(t *testing.T) {
 
 	n = db.count("bar")
 	if n != 0 {
-		t.Errorf("count should be 0, got %v", n)
+		t.Errorf(`db.count("bar") should be 0, got %v`, n)
 	}
 
 	db.rollback()
+
 	val = db.get("a")
 	if val == nil || *val != "bar" {
 		t.Errorf("val should be bar, got %v", *val)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+)
+
+func Test(t *testing.T) {
+
+	db := database{}
+	db.store = make(map[string]string)
+	db.setBuf = make(map[string]string)
+
+	var val *string
+	var n uint
+
+	val = db.get("foo")
+	if val != nil {
+		t.Errorf("value should be nil, got %v", val)
+	}
+
+	db.set("a", "foo")
+	db.set("b", "foo")
+	n = db.count("foo")
+	if n != 2 {
+		t.Errorf("count should be 2, got %v", n)
+	}
+
+	n = db.count("bar")
+	if n != 0 {
+		t.Errorf("count should be 0, got %v", n)
+	}
+
+	db.delete("a")
+
+	n = db.count("foo")
+	if n != 1 {
+		t.Errorf("count should be 0, got %v", n)
+	}
+
+	db.set("b", "baz")
+
+	val = db.get("B")
+	if val != nil {
+		t.Errorf("value should be nil, got %v", val)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func Test(t *testing.T) {
+func TestExample1(t *testing.T) {
 
 	db := database{}
 	db.store = make(map[string]string)
@@ -34,7 +34,7 @@ func Test(t *testing.T) {
 
 	n = db.count("foo")
 	if n != 1 {
-		t.Errorf("count should be 0, got %v", n)
+		t.Errorf("count should be 1, got %v", n)
 	}
 
 	db.set("b", "baz")
@@ -42,5 +42,38 @@ func Test(t *testing.T) {
 	val = db.get("B")
 	if val != nil {
 		t.Errorf("value should be nil, got %v", val)
+	}
+}
+
+func TestExample2(t *testing.T) {
+
+	db := database{}
+	db.store = make(map[string]string)
+	db.setBuf = make(map[string]string)
+
+	var val *string
+	var n uint
+
+	db.set("a", "foo")
+	db.set("a", "foo")
+	n = db.count("foo")
+	if n != 1 {
+		t.Errorf("count should be 1, got %v", n)
+	}
+
+	val = db.get("a")
+	if val == nil || *val != "foo" {
+		t.Errorf("val should be foo, got %v", val)
+	}
+
+	db.delete("a")
+	val = db.get("a")
+	if val != nil {
+		t.Errorf("val should be nil, got %v", val)
+	}
+
+	n = db.count("foo")
+	if n != 0 {
+		t.Errorf("count should be 0, got %v", n)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -142,12 +142,14 @@ func TestExample4(t *testing.T) {
 	}
 
 	db.begin()
+
 	n = db.count("bar")
 	if n != 1 {
 		t.Errorf("count should be 1, got %v", n)
 	}
 
 	db.delete("a")
+
 	val = db.get("a")
 	if val != nil {
 		t.Errorf("val should be nil, got %v", *val)

--- a/main_test.go
+++ b/main_test.go
@@ -77,3 +77,41 @@ func TestExample2(t *testing.T) {
 		t.Errorf("count should be 0, got %v", n)
 	}
 }
+
+func TestExample3(t *testing.T) {
+
+	db := database{}
+	db.store = make(map[string]string)
+	db.setBuf = make(map[string]string)
+
+	var val *string
+	// var n uint
+
+	db.begin()
+
+	db.set("a", "foo")
+	val = db.get("a")
+	if val == nil || *val != "foo" {
+		t.Errorf("val should be foo, got %v", val)
+	}
+
+	db.begin()
+
+	db.set("a", "bar")
+	val = db.get("a")
+	if val == nil || *val != "bar" {
+		t.Errorf("val should be bar, got %v", val)
+	}
+
+	db.rollback()
+	val = db.get("a")
+	if val == nil || *val != "foo" {
+		t.Errorf("val should be foo, got %v", val)
+	}
+
+	db.rollback()
+	val = db.get("a")
+	if val != nil {
+		t.Errorf("val should be nil, got %v", val)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -6,9 +6,9 @@ import (
 
 func TestExample1(t *testing.T) {
 
-	db := database{}
-	db.store = make(map[string]string)
-	db.setBuf = make(map[string]string)
+	db := database{
+		store: make(map[string]string),
+	}
 
 	var val *string
 	var n uint
@@ -47,9 +47,9 @@ func TestExample1(t *testing.T) {
 
 func TestExample2(t *testing.T) {
 
-	db := database{}
-	db.store = make(map[string]string)
-	db.setBuf = make(map[string]string)
+	db := database{
+		store: make(map[string]string),
+	}
 
 	var val *string
 	var n uint
@@ -80,9 +80,9 @@ func TestExample2(t *testing.T) {
 
 func TestExample3(t *testing.T) {
 
-	db := database{}
-	db.store = make(map[string]string)
-	db.setBuf = make(map[string]string)
+	db := database{
+		store: make(map[string]string),
+	}
 
 	var val *string
 	// var n uint
@@ -118,9 +118,9 @@ func TestExample3(t *testing.T) {
 
 func TestExample4(t *testing.T) {
 
-	db := database{}
-	db.store = make(map[string]string)
-	db.setBuf = make(map[string]string)
+	db := database{
+		store: make(map[string]string),
+	}
 
 	var val *string
 	var n uint


### PR DESCRIPTION
this pr fixes the bugs related to the initial release [here](https://github.com/atecce/devoted/tree/ca80419383843a06328d71da27224cfcc5105126) which stemmed from its inability to arbitrarily nest a stack of transactions (instead it simply assumed one transaction at a time and cleared any existing one on a `begin`).

the initial implementation was pretty extensible, and the meat of the change was defining a new type, `transaction` which owned the existing mutable state of `setBuf` and `deleteBuf` and acted as layers above the `store`

had a bit of a headache with reference semantics, and going backwards in time through the `txs` to properly `count` deleted items. but i got through it and now all the tests pass

this is fun :D